### PR TITLE
Add yaml from existing production nodeport service

### DIFF
--- a/frankfurt/nucleus-prod/nodeport-svc.yaml
+++ b/frankfurt/nucleus-prod/nodeport-svc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: nucleus-prod
+  name: nucleus-nodeport
+  namespace: nucleus-prod
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+  - name: https
+    nodePort: 31758
+    port: 443
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: nucleus-prod
+    type: cmd
+  sessionAffinity: None
+  type: NodePort
+status:
+  # existing ELB managed by tf not k8s
+  loadBalancer: {}


### PR DESCRIPTION
mozmeao/infra#1117

kubectl get svc nucleus-nodeport -o yaml > nodeport-svc.yaml

Edited for clarity