### PR TITLE
Remove timeout param from kubectl versions that don't support it

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,8 @@ deploy frankfurt dev:
     - frankfurt
   script:
     - kubectl_1.11 apply -f frankfurt/nucleus-dev
-    - kubectl_1.11 rollout status -f frankfurt/nucleus-dev/deploy.yaml -w --timeout=10m
+    # --timeout requires kubectl 1.12+
+    - kubectl_1.11 rollout status -f frankfurt/nucleus-dev/deploy.yaml -w
 
 deploy iowa-b dev:
   variables:
@@ -38,7 +39,8 @@ deploy frankfurt stage:
     - stage
   script:
     - kubectl_1.11 apply -f frankfurt/nucleus-stage
-    - kubectl_1.11 rollout status -f frankfurt/nucleus-stage/deploy.yaml -w --timeout=10m
+    # --timeout requires kubectl 1.12+
+    - kubectl_1.11 rollout status -f frankfurt/nucleus-stage/deploy.yaml -w
 
 deploy iowa-b stage:
   variables:
@@ -52,7 +54,7 @@ deploy iowa-b stage:
     - stage
   script:
     - kubectl_1.12 apply -f iowa-b/nucleus-stage
-    - kubectl_1.12 rollout status -f iowa-b/nucleus-stage/deploy.yaml -w --timeout=10m
+    - kubectl_1.12 rollout status -f iowa-b/nucleus-stage/deploy.yaml -w
 
 deploy frankfurt prod:
   variables:
@@ -68,7 +70,8 @@ deploy frankfurt prod:
     - frankfurt-prod
   script:
     - kubectl_1.11 apply -f frankfurt/nucleus-prod
-    - kubectl_1.11 rollout status -f frankfurt/nucleus-prod/deploy.yaml -w --timeout=10m
+    # --timeout requires kubectl 1.12+
+    - kubectl_1.11 rollout status -f frankfurt/nucleus-prod/deploy.yaml -w
 
 deploy iowa-b prod:
   variables:


### PR DESCRIPTION
Address failures such as https://gitlab.com/mozmeao/nucleus-config/-/jobs/218181469