### PR TITLE
Switch the nucleus services to use tcp for backend communications

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ deploy frankfurt dev:
       - mozmeao-fr/nucleus-dev/*
     refs:
       - master
-      - tcp_backend
 
 deploy frankfurt stage:
   extends: .deploy-aws

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,7 @@ deploy frankfurt dev:
       - mozmeao-fr/nucleus-dev/*
     refs:
       - master
+      - tcp_backend
 
 deploy frankfurt stage:
   extends: .deploy-aws

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,10 @@ stages:
   tags:
     - aws
     - mozmeao
+  variables:
+    INGRESSFILENAME: ingress-controller.sh
   script:
+    - if [ -f "${DEPLOYMENT}/${INGRESSFILENAME}" ]; then ./${DEPLOYMENT}/${INGRESSFILENAME} ; fi
     - kubectl apply -f ${DEPLOYMENT}
     - ./rollout-status.sh ${DEPLOYMENT}
 
@@ -15,6 +18,7 @@ deploy frankfurt dev:
   variables:
     DEPLOYMENT: mozmeao-fr/nucleus-dev
     KUBECONFIG: /home/gitlab-runner/.kube/mozmeao-fr-1.kubeconfig
+    NS: nucleus-dev
   only:
     changes:
       - mozmeao-fr/nucleus-dev/*
@@ -25,7 +29,8 @@ deploy frankfurt stage:
   extends: .deploy-aws
   variables:
     DEPLOYMENT: mozmeao-fr/nucleus-stage
-    KUBECONFIG: /home/gitlab-runner/.kube/mozmeao-fr-1.kubeconfig
+
+    NS: nucleus-stage
   only:
     changes:
       - mozmeao-fr/nucleus-stage/*
@@ -37,6 +42,7 @@ deploy frankfurt prod:
   variables:
     DEPLOYMENT: mozmeao-fr/nucleus-prod
     KUBECONFIG: /home/gitlab-runner/.kube/mozmeao-fr-1.kubeconfig
+    NS: nucleus-prod
   only:
     changes:
       - mozmeao-fr/nucleus-prod/*

--- a/mozmeao-fr/nucleus-dev/helm_configs/ingress.yml
+++ b/mozmeao-fr/nucleus-dev/helm_configs/ingress.yml
@@ -6,5 +6,6 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
       service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=dev,Service=nucleus,Region=fr"
   scope:
     enabled: true

--- a/mozmeao-fr/nucleus-dev/helm_configs/ingress.yml
+++ b/mozmeao-fr/nucleus-dev/helm_configs/ingress.yml
@@ -1,0 +1,10 @@
+controller:
+  useIngressClassOnly: true
+  service:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: "nucleus.dev.fr.moz.works"
+      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+  scope:
+    enabled: true

--- a/mozmeao-fr/nucleus-dev/ingress-controller.sh
+++ b/mozmeao-fr/nucleus-dev/ingress-controller.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+
+HELMOPTIONS=$(cat << EOM
+  --namespace $NS \
+  -f $DEPLOYMENT/helm_configs/ingress.yml \
+  nucleus-dev-ingress ingress-nginx/ingress-nginx
+EOM
+)
+
+echo "Options are:"
+echo "$HELMOPTIONS"
+
+# shellcheck disable=SC2086
+helm upgrade --install $HELMOPTIONS

--- a/mozmeao-fr/nucleus-dev/ingress.yml
+++ b/mozmeao-fr/nucleus-dev/ingress.yml
@@ -15,6 +15,7 @@ spec:
       name: letsencrypt
     solvers:
       - dns01:
+          cnameStrategy: Follow
           route53:
             region: us-west-2
 ---
@@ -48,8 +49,16 @@ spec:
               serviceName: nucleus-dev-ingress
               servicePort: 8000
             path: /
+    - host: "nucleus-dev.allizom.org"
+      http:
+        paths:
+          - backend:
+              serviceName: nucleus-dev-ingress
+              servicePort: 8000
+            path: /
   # This section is only required if TLS is to be enabled for the Ingress
   tls:
       - hosts:
           - "nucleus.dev.fr.moz.works"
+          - "nucleus-dev.allizom.org"
         secretName: nucleus-tls

--- a/mozmeao-fr/nucleus-dev/ingress.yml
+++ b/mozmeao-fr/nucleus-dev/ingress.yml
@@ -1,0 +1,55 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: letsencrypt
+  namespace: nucleus-dev
+spec:
+  acme:
+    # You must replace this email address with your own.
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: it-se@mozilla.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # Secret resource used to store the account's private key.
+      name: letsencrypt
+    solvers:
+      - dns01:
+          route53:
+            region: us-west-2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nucleus-dev-ingress
+  namespace: nucleus-dev
+spec:
+  ports:
+  - port: 8000
+    targetPort: 8000
+  selector:
+    app: nucleus-dev
+    type: web
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/issuer: letsencrypt
+  name: nucleus-dev
+  namespace: nucleus-dev
+spec:
+  rules:
+    - host: "nucleus.dev.fr.moz.works"
+      http:
+        paths:
+          - backend:
+              serviceName: nucleus-dev-ingress
+              servicePort: 8000
+            path: /
+  # This section is only required if TLS is to be enabled for the Ingress
+  tls:
+      - hosts:
+          - "nucleus.dev.fr.moz.works"
+        secretName: nucleus-tls

--- a/mozmeao-fr/nucleus-prod/helm_configs/ingress.yml
+++ b/mozmeao-fr/nucleus-prod/helm_configs/ingress.yml
@@ -6,5 +6,6 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
       service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+      service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "Environment=prod,Service=nucleus,Region=fr"
   scope:
     enabled: true

--- a/mozmeao-fr/nucleus-prod/helm_configs/ingress.yml
+++ b/mozmeao-fr/nucleus-prod/helm_configs/ingress.yml
@@ -2,7 +2,7 @@ controller:
   useIngressClassOnly: true
   service:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: "nucleus.prod.fr.moz.works"
+      external-dns.alpha.kubernetes.io/hostname: "nucleus.prod.fr.moz.works,nucleus.moz.works"
       service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
       service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
       service.beta.kubernetes.io/aws-load-balancer-type: "nlb"

--- a/mozmeao-fr/nucleus-prod/helm_configs/ingress.yml
+++ b/mozmeao-fr/nucleus-prod/helm_configs/ingress.yml
@@ -1,0 +1,10 @@
+controller:
+  useIngressClassOnly: true
+  service:
+    annotations:
+      external-dns.alpha.kubernetes.io/hostname: "nucleus.prod.fr.moz.works"
+      service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+  scope:
+    enabled: true

--- a/mozmeao-fr/nucleus-prod/ingress-controller.sh
+++ b/mozmeao-fr/nucleus-prod/ingress-controller.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+
+HELMOPTIONS=$(cat << EOM
+  --namespace $NS \
+  -f $DEPLOYMENT/helm_configs/ingress.yml \
+  nucleus-prod-ingress ingress-nginx/ingress-nginx
+EOM
+)
+
+echo "Options are:"
+echo "$HELMOPTIONS"
+
+# shellcheck disable=SC2086
+helm upgrade --install $HELMOPTIONS

--- a/mozmeao-fr/nucleus-prod/ingress.yml
+++ b/mozmeao-fr/nucleus-prod/ingress.yml
@@ -1,0 +1,63 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: letsencrypt
+  namespace: nucleus-prod
+spec:
+  acme:
+    # You must replace this email address with your own.
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: it-se@mozilla.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # Secret resource used to store the account's private key.
+      name: letsencrypt
+    solvers:
+      - dns01:
+          route53:
+            region: us-west-2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nucleus-prod-ingress
+  namespace: nucleus-prod
+spec:
+  ports:
+  - port: 8000
+    targetPort: 8000
+  selector:
+    app: nucleus-prod
+    type: web
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/issuer: letsencrypt
+  name: nucleus-prod
+  namespace: nucleus-prod
+spec:
+  rules:
+    - host: "nucleus.prod.fr.moz.works"
+      http:
+        paths:
+          - backend:
+              serviceName: nucleus-prod-ingress
+              servicePort: 8000
+            path: /
+    - host: "moz.works"
+      http:
+        paths:
+          - backend:
+              serviceName: nucleus-prod-ingress
+              servicePort: 8000
+            path: /
+  # This section is only required if TLS is to be enabled for the Ingress
+  tls:
+      - hosts:
+          - "nucleus.prod.fr.moz.works"
+          - "nucleus.moz.works"
+        secretName: nucleus-tls

--- a/mozmeao-fr/nucleus-prod/ingress.yml
+++ b/mozmeao-fr/nucleus-prod/ingress.yml
@@ -15,6 +15,7 @@ spec:
       name: letsencrypt
     solvers:
       - dns01:
+          cnameStrategy: Follow
           route53:
             region: us-west-2
 ---


### PR DESCRIPTION
Through experimentation it seemed like tcp/ssl as
instance/backend protocol seemed to fix the truncation
of large files.  This change is to switch nucleus to that setup.