### PR TITLE
nucleus-dev/prod: Pin ingress-nginx chart to 3.36.0 to defer Kubernetes upgrade [SE-2509]

### DIFF
--- a/mozmeao-fr/nucleus-dev/ingress-controller.sh
+++ b/mozmeao-fr/nucleus-dev/ingress-controller.sh
@@ -3,8 +3,13 @@
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
 
+# We pin to helm chart version 3.36.0, which provides appVersion 0.49.0,
+# which is the latest release as of today that doesn't contain app 1.0+
+# with a breaking change to require kubeVersion 1.19+. -- 20210830 atoll
+
 HELMOPTIONS=$(cat << EOM
   --namespace $NS \
+  --version 3.36.0 \
   -f $DEPLOYMENT/helm_configs/ingress.yml \
   nucleus-dev-ingress ingress-nginx/ingress-nginx
 EOM

--- a/mozmeao-fr/nucleus-prod/ingress-controller.sh
+++ b/mozmeao-fr/nucleus-prod/ingress-controller.sh
@@ -3,8 +3,13 @@
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
 
+# We pin to helm chart version 3.36.0, which provides appVersion 0.49.0,
+# which is the latest release as of today that doesn't contain app 1.0+
+# with a breaking change to require kubeVersion 1.19+. -- 20210830 atoll
+
 HELMOPTIONS=$(cat << EOM
   --namespace $NS \
+  --version 3.36.0 \
   -f $DEPLOYMENT/helm_configs/ingress.yml \
   nucleus-prod-ingress ingress-nginx/ingress-nginx
 EOM


### PR DESCRIPTION
Bedrock was on kubeVersion v1.17.17-eks-087e67, but the ingress-nginx module v1.0.0 includes a breaking change that requires kube 1.19.0-0. So we're pinning to ingress-nginx chart 3.36.0, so that we can get the latest release in the v0 series while avoiding the v1+ until our kube catches up.