### PR TITLE
chore(ingress): Update ingress for security

### DIFF
--- a/mozmeao-fr/nucleus-dev/ingress-controller.sh
+++ b/mozmeao-fr/nucleus-dev/ingress-controller.sh
@@ -3,13 +3,9 @@
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
 
-# We pin to helm chart version 3.36.0, which provides appVersion 0.49.0,
-# which is the latest release as of today that doesn't contain app 1.0+
-# with a breaking change to require kubeVersion 1.19+. -- 20210830 atoll
-
 HELMOPTIONS=$(cat << EOM
   --namespace $NS \
-  --version 3.36.0 \
+  --version 3.37.0 \
   -f $DEPLOYMENT/helm_configs/ingress.yml \
   nucleus-dev-ingress ingress-nginx/ingress-nginx
 EOM

--- a/mozmeao-fr/nucleus-prod/ingress-controller.sh
+++ b/mozmeao-fr/nucleus-prod/ingress-controller.sh
@@ -3,13 +3,9 @@
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
 
-# We pin to helm chart version 3.36.0, which provides appVersion 0.49.0,
-# which is the latest release as of today that doesn't contain app 1.0+
-# with a breaking change to require kubeVersion 1.19+. -- 20210830 atoll
-
 HELMOPTIONS=$(cat << EOM
   --namespace $NS \
-  --version 3.36.0 \
+  --version 3.37.0 \
   -f $DEPLOYMENT/helm_configs/ingress.yml \
   nucleus-prod-ingress ingress-nginx/ingress-nginx
 EOM


### PR DESCRIPTION
Tried out `dev` manually and seemed to work fine. Cluster is currently on 1.19 so I think we should be good here.